### PR TITLE
Update documentation examples and rules references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,14 +54,14 @@ docs/
 - Rules functions in `src/rules/` must have corresponding test files.
 - Tests go next to the file they test: `ability-scores.ts` → `ability-scores.test.ts`.
 - Step components get tests in their step directory: `RaceStep/RaceStep.test.tsx`.
-- Use concrete SRD values in tests (e.g., Hill Dwarf gets +2 CON, +1 WIS) rather than abstract placeholders.
+- Use concrete SRD values in tests (e.g., Acolyte background grants +1 to two abilities and +2 to one) rather than abstract placeholders.
 
 ## D&D Rules References
 
 Task-specific rules references are in `docs/rules/`. Consult the relevant file before implementing any game logic:
 
-- `ability-scores.md` — modifier formula, point buy costs/budget, standard array, racial bonus application
-- `races.md` — racial traits, ability bonuses, subraces
+- `ability-scores.md` — modifier formula, point buy costs/budget, standard array, background-based bonus application
+- `races.md` — racial traits, creature type, size, speed, special senses
 - `classes.md` — hit dice, primary abilities, saving throw proficiencies, class features at level 1
 - `backgrounds.md` — skill proficiencies, equipment, feature
 - `equipment-and-armor.md` — AC calculation, weapon properties


### PR DESCRIPTION
## Summary
Updated CLAUDE.md to reflect more accurate D&D 5e rules references and better align test examples with actual game mechanics, particularly around background ability bonuses rather than racial bonuses.

## Key Changes
- Updated test example to use background ability bonuses (Acolyte background: +1 to two abilities, +2 to one) instead of racial bonuses, providing a more relevant concrete SRD reference
- Refined `ability-scores.md` rules reference description to emphasize background-based bonus application alongside existing point buy and standard array mechanics
- Clarified `races.md` rules reference to focus on core racial mechanics (traits, creature type, size, speed, special senses) rather than ability bonuses, which are now primarily associated with backgrounds in 5e

## Details
These documentation updates improve clarity for developers implementing character creation logic by:
1. Providing test examples that align with 5e's background system
2. Properly categorizing which rules documents cover ability score modifications
3. Ensuring rules references accurately reflect the scope of each documentation file

https://claude.ai/code/session_01DJH8jaxAftMjonLRHLwVWg