### PR TITLE
fix(workflows): use latest issue plan comment for PR body

### DIFF
--- a/.github/workflows/agent-issue-approved-create-pr.yml
+++ b/.github/workflows/agent-issue-approved-create-pr.yml
@@ -110,8 +110,28 @@ jobs:
           else
             TITLE="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title -q .title)"
 
-            PLAN="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
-              -q '.comments | map(select(.body | test("^## Plan v[0-9]+"))) | last | .body // ""')"
+            gh api --paginate "/repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" --jq '.[]' > comments.jsonl
+
+            PLAN="$(jq -rs '
+              map(select(.body | type == "string"))
+              | map(select(.body | test("(?m)^## Plan v[0-9]+\\b")))
+              | map(
+                  . + {
+                    version: (
+                      .body
+                      | capture("(?m)^## Plan v(?<version>[0-9]+)\\b")
+                      | .version
+                      | tonumber
+                    )
+                  }
+                )
+              | sort_by(.version, .created_at)
+              | last
+              | .body // ""
+            ' comments.jsonl)"
+
+            rm -f comments.jsonl
+
             if [ -z "$PLAN" ]; then
               PLAN="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body -q .body)"
             fi
@@ -154,4 +174,3 @@ jobs:
           fi
 
           gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "$MESSAGE"
-


### PR DESCRIPTION
### Motivation
- The PR creation workflow was using the issue body (or an unreliable `gh issue view` comments query) for the PR body, which could pick up the original planning prompt instead of the most recent approved plan comment when plans are revised.

### Description
- Replace the `gh issue view ... --json comments` approach with a paginated `gh api` call to fetch all issue comments into `comments.jsonl` for reliable comment enumeration.
- Add `jq` logic to select only comments whose body begins with `## Plan vN`, parse the numeric `vN`, sort by `version` and `created_at`, and pick the latest plan comment as the PR body.
- Keep the existing fallback to the issue body when no plan comment is found and remove the temporary `comments.jsonl` file after extraction.

### Testing
- Ran `git diff --check && git status --short`, which completed successfully and showed the updated workflow file with no whitespace/diff errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993cdeaa3ec832db63ceeeb501768ce)