### PR TITLE
ci: allow agentic-automation-app[bot] to trigger Claude workflows

### DIFF
--- a/.github/workflows/agent-issue-plan.yml
+++ b/.github/workflows/agent-issue-plan.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: agentic-automation-app[bot]
           track_progress: true
           claude_args: |
             --max-turns 60

--- a/.github/workflows/agent-issue-revise-plan.yml
+++ b/.github/workflows/agent-issue-revise-plan.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: agentic-automation-app[bot]
           track_progress: true
           claude_args: |
             --max-turns 60

--- a/.github/workflows/agent-pr-implement.yml
+++ b/.github/workflows/agent-pr-implement.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: agentic-automation-app[bot]
           claude_args: |
             --model opus
             --max-turns 120

--- a/.github/workflows/agent-pr-review.yml
+++ b/.github/workflows/agent-pr-review.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: agentic-automation-app[bot]
           claude_args: |
             --model opus
             --max-turns 45

--- a/.github/workflows/claude-implement-in-pr.yml
+++ b/.github/workflows/claude-implement-in-pr.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           show_full_output: true
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: agentic-automation-app[bot]
           track_progress: true
 
           # IMPORTANT: no '#' comment lines inside this block

--- a/.github/workflows/claude-plan-from-issue.yml
+++ b/.github/workflows/claude-plan-from-issue.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@01e756b34ef7a1447e9508f674143b07d20c2631
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: agentic-automation-app[bot]
           track_progress: true
 
           # Optional: keep planning read-only

--- a/.github/workflows/claude-pr-comment-trigger.yml
+++ b/.github/workflows/claude-pr-comment-trigger.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.CLAUDE_PUSH_TOKEN }}
+          allowed_bots: agentic-automation-app[bot]
           trigger_phrase: "@claude"
           show_full_output: true
 
@@ -97,6 +98,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.CLAUDE_PUSH_TOKEN }}
+          allowed_bots: agentic-automation-app[bot]
           trigger_phrase: "@claude"
           show_full_output: true
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: agentic-automation-app[bot]
 
           track_progress: true
           include_fix_links: true


### PR DESCRIPTION
### Motivation
- Comment-triggered workflows using the Claude Code action were not being invoked when comments were created by the GitHub App bot; the Claude action needs the `allowed_bots` entry to accept bot-authored triggers.

### Description
- Added `allowed_bots: agentic-automation-app[bot]` to every workflow step that invokes `anthropics/claude-code-action` to permit the GitHub App bot as a triggering actor.
- Updated workflow files: `.github/workflows/agent-issue-plan.yml`, `.github/workflows/agent-issue-revise-plan.yml`, `.github/workflows/agent-pr-implement.yml`, `.github/workflows/agent-pr-review.yml`, `.github/workflows/claude-implement-in-pr.yml`, `.github/workflows/claude-plan-from-issue.yml`, `.github/workflows/claude-pr-comment-trigger.yml` (both PR and Issue mode steps), and `.github/workflows/claude-pr-review.yml`.
- No other logic or runtime settings were changed outside these YAML additions.

### Testing
- Verified the new key is present with `rg -n "allowed_bots: agentic-automation-app\\[bot\\]" .github/workflows/*.yml` and the command returned matches in the updated files.
- Confirmed each Claude action step includes the allowed bot with `rg -n "uses: anthropics/claude-code-action|allowed_bots: agentic-automation-app\\[bot\\]" .github/workflows/*.yml` which succeeded.
- Validated that only workflow YAML files under `.github/workflows/` were modified and no other files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993d2020d94832d8c9f24410dd1cb31)