### PR TITLE
Fix agent PR review guardrail label checks under set -e

### DIFF
--- a/.github/workflows/agent-pr-review.yml
+++ b/.github/workflows/agent-pr-review.yml
@@ -50,8 +50,15 @@ jobs:
           REPO="${{ github.repository }}"
           LABELS="$(gh pr view "$PR" --repo "$REPO" --json labels -q '.labels[].name')"
 
-          echo "$LABELS" | grep -q '^HALTED$' && { echo "HALTED set; exiting."; exit 0; }
-          echo "$LABELS" | grep -q '^AWAITING-FEEDBACK$' && { echo "AWAITING-FEEDBACK set; exiting."; exit 0; }
+          if echo "$LABELS" | grep -qx 'HALTED'; then
+            echo "HALTED set; exiting."
+            exit 0
+          fi
+
+          if echo "$LABELS" | grep -qx 'AWAITING-FEEDBACK'; then
+            echo "AWAITING-FEEDBACK set; exiting."
+            exit 0
+          fi
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Motivation
- Prevent the PR review workflow step from failing when label queries return empty by avoiding `grep` returning non-zero under `set -euo pipefail` while preserving the intended skip behavior for `HALTED` and `AWAITING-FEEDBACK`.

### Description
- Replace `echo "$LABELS" | grep -q '^HALTED$' && ...` / `grep -q '^AWAITING-FEEDBACK$' && ...` with explicit `if` blocks using `grep -qx` and `exit 0` in `.github/workflows/agent-pr-review.yml` so `grep` non-matches no longer cause the step to fail.

### Testing
- Ran a shell reproduction with `set -euo pipefail` and an empty `LABELS` value using the updated `grep -qx` `if` pattern to confirm the step exits normally when labels are absent, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993d9dd0bf4832da96aef974ce551a9)