### PR TITLE
Restore interactive review commenting in Agent PR Review workflow

### DIFF
--- a/.github/workflows/agent-pr-review.yml
+++ b/.github/workflows/agent-pr-review.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Export token for gh
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
-
       - name: Fork guard (same-repo branches only)
         run: |
           set -euo pipefail
@@ -67,25 +66,15 @@ jobs:
       - name: Checkout PR branch
         run: gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
 
-      - name: Post review progress comment
-        id: review-progress
-        run: |
-          set -euo pipefail
-          PR="${{ github.event.issue.number }}"
-          REPO="${{ github.repository }}"
-
-          COMMENT_ID="$(gh api repos/"$REPO"/issues/"$PR"/comments \
-            --method POST \
-            --field body='🔍 Agent review started. I will update this comment with findings and final verdict once analysis is complete.' \
-            --jq '.id')"
-
-          echo "comment_id=$COMMENT_ID" >> "$GITHUB_OUTPUT"
-
-      - uses: anthropics/claude-code-action@v1
+      - name: Agent PR review (interactive comment mode)
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: agentic-automation-app[bot]
+          track_progress: true
+          include_fix_links: true
+          show_full_output: true
           claude_args: |
             --model opus
             --max-turns 45
@@ -94,17 +83,9 @@ jobs:
             You are the REVIEW agent.
 
             IMPORTANT WORKFLOW REQUIREMENT
-            - A progress comment has already been created for this run.
-            - Update that existing comment in place (do not create a new final review comment).
-            - Progress comment id: ${{ steps.review-progress.outputs.comment_id }}
-            - Repository: ${{ github.repository }}
-            - PR number: ${{ github.event.issue.number }}
-            - Use gh api patch to update comment body, e.g.:
-              gh api repos/${{ github.repository }}/issues/comments/${{ steps.review-progress.outputs.comment_id }} --method PATCH --field body@- <<'EOF'
-              ...comment body...
-              EOF
-            - While working, first update the comment with an "in progress" note, then replace with final review output.
-            - Your final comment body MUST include exactly one verdict line:
+            - Use interactive review commenting style (progress updates + final review comment with findings).
+            - Post your final review as a normal PR comment (do not overwrite prior comments).
+            - Your final review comment body MUST include exactly one verdict line:
               Verdict: APPROVE
               or
               Verdict: CHANGES_REQUESTED
@@ -162,7 +143,7 @@ jobs:
             - Include 1-3 items max. If there are more, include ONE item titled "Follow-ups" with a checklist in the description.
             - If there are no follow-ups, omit the section entirely.
 
-            OUTPUT FORMAT (single PR comment)
+            OUTPUT FORMAT (single final PR review comment)
 
             Start with:
 
@@ -217,25 +198,3 @@ jobs:
           fi
 
           echo "No recognized verdict; leaving labels as-is."
-
-      - name: Ensure progress comment reflects review outcome
-        if: always()
-        run: |
-          set -euo pipefail
-          REPO="${{ github.repository }}"
-          COMMENT_ID="${{ steps.review-progress.outputs.comment_id }}"
-          VERDICT="${{ steps.apply-verdict.outputs.verdict }}"
-
-          if [ -z "${COMMENT_ID}" ]; then
-            echo "No progress comment id available; skipping final status update."
-            exit 0
-          fi
-
-          if [ "${VERDICT}" = "APPROVE" ] || [ "${VERDICT}" = "APPROVED" ] || [ "${VERDICT}" = "CHANGES_REQUESTED" ]; then
-            echo "Recognized verdict already present; leaving detailed review comment untouched."
-            exit 0
-          fi
-
-          gh api repos/"$REPO"/issues/comments/"$COMMENT_ID" \
-            --method PATCH \
-            --field body="⚠️ Review run completed, but no machine-readable verdict was detected.\n\nPlease re-run /agent-review so the final updated comment includes one of:\n- Verdict: APPROVE\n- Verdict: CHANGES_REQUESTED"


### PR DESCRIPTION
### Motivation
- Restore the older interactive/commenting UX from the Claude review flow for the Agent PR review while keeping the newer trigger and verdict automation intact. 
- Make reviews friendlier (progress updates + normal final review comment) without changing the `/agent-review` trigger, fork guard, or downstream verdict actions.

### Description
- Updated `/.github/workflows/agent-pr-review.yml` to enable interactive features on the Claude action by adding `track_progress: true`, `include_fix_links: true`, and `show_full_output: true`. 
- Removed the custom single progress-comment creation and in-place patch/overwrite flow so the agent can emit progress updates and then post a normal final PR comment. 
- Adjusted the agent prompt to instruct posting a final review comment (containing a single `Verdict: APPROVE` or `Verdict: CHANGES_REQUESTED` line) instead of overwriting a prior comment. 
- Preserved existing guards and automation: the `/agent-review` trigger, fork guard, `HALTED`/`AWAITING-FEEDBACK` checks, and verdict parsing/dispatch (no-op for `APPROVE`, dispatch `agent-implement` on `CHANGES_REQUESTED`) remain unchanged.

### Testing
- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/agent-pr-review.yml'); puts 'ok'"`, which succeeded. 
- Ran `git diff --check` to validate whitespace/style issues, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dfddbb78832d9997daa1433906ef)