### PR TITLE
Use 'Closes' keyword in PR body to auto-close linked issues on merge

### DIFF
--- a/.github/workflows/agent-issue-approved-create-pr.yml
+++ b/.github/workflows/agent-issue-approved-create-pr.yml
@@ -136,7 +136,7 @@ jobs:
               PLAN="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body -q .body)"
             fi
 
-            BODY="$(printf "Implements: #%s\n\n%s\n" "$ISSUE_NUMBER" "$PLAN")"
+            BODY="$(printf "Closes #%s\n\n%s\n" "$ISSUE_NUMBER" "$PLAN")"
 
             PR_URL="$(gh pr create --repo "$REPO" \
               --title "$TITLE" \

--- a/.github/workflows/agent-pr-implement.yml
+++ b/.github/workflows/agent-pr-implement.yml
@@ -98,7 +98,7 @@ jobs:
 
             0) Locate the authoritative plan (do this first)
             - The PR body contains the authoritative implementation plan. Use it as the single source of truth.
-            - The PR body also includes a reference like "Implements: #<N>". You may open the linked issue for extra context,
+            - The PR body also includes a reference like "Closes #<N>". You may open the linked issue for extra context,
               but do not replace or override the PR-body plan with issue comments.
 
             1) Resume check (before coding)


### PR DESCRIPTION
'Implements:' is not a GitHub closing keyword, so linked issues were
not automatically closed when PRs were merged. Changed to 'Closes #N'
which GitHub recognizes for auto-closing. Updated the implementer
agent prompt to match.

https://claude.ai/code/session_01J6Go8sjwwYd55b6R3RyvEc