### PR TITLE
Add Haiku model option to agentic workflows

### DIFF
--- a/.github/workflows/agent-issue-approved-create-pr.yml
+++ b/.github/workflows/agent-issue-approved-create-pr.yml
@@ -155,7 +155,18 @@ jobs:
       - name: Trigger implementation on PR
         run: |
           set -euo pipefail
-          gh pr comment "${{ steps.create_pr.outputs.pr_number }}" --repo "${{ github.repository }}" --body "/agent-implement"
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+          REPO="${{ github.repository }}"
+
+          NEXT_MODEL="$(gh api --paginate "/repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100" \
+            --jq '.[]' \
+            | jq -rs '[.[] | select(.body | type == "string") | select(.body | test("(?m)^## Plan v[0-9]+\\b")) | .body] | last // ""' \
+            | grep -oP '(?<=<!-- next-model: )\w+' || true)"
+          if ! echo "$NEXT_MODEL" | grep -qE '^(opus|sonnet|haiku)$'; then
+            NEXT_MODEL="opus"
+          fi
+
+          gh pr comment "${{ steps.create_pr.outputs.pr_number }}" --repo "$REPO" --body "/agent-implement $NEXT_MODEL"
 
       - name: Comment on issue with PR link
         run: |

--- a/.github/workflows/agent-issue-plan.yml
+++ b/.github/workflows/agent-issue-plan.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Export token for gh
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
+      - name: Parse model from trigger comment
+        id: model
+        run: |
+          set -euo pipefail
+          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
+            echo "value=$WORD2" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=sonnet" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -36,6 +47,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
+            --model ${{ steps.model.outputs.value }}
             --max-turns 60
             --settings ./claude/agents/planner.json
           prompt: |

--- a/.github/workflows/agent-issue-plan.yml
+++ b/.github/workflows/agent-issue-plan.yml
@@ -75,6 +75,12 @@ jobs:
             - A single issue comment starting with:
               "## Plan v1"
             - Do not create a PR.
+            - Before the approve/revise footer, include a model recommendation for the implementation agent:
+              <!-- next-model: X -->
+              where X is haiku, sonnet, or opus, based on the complexity of the work planned:
+              - haiku: trivial change (docs, minor copy, single-line fix, config tweak)
+              - sonnet: moderate change (typical feature, a few files, standard patterns)
+              - opus: complex change (multi-system, high-risk logic, intricate interactions)
             - End the comment with:
               To approve, comment with "/agent-approve".
               To revise, comment with "/plan-revise" followed by the requested revisions.

--- a/.github/workflows/agent-issue-plan.yml
+++ b/.github/workflows/agent-issue-plan.yml
@@ -30,9 +30,11 @@ jobs:
 
       - name: Parse model from trigger comment
         id: model
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          WORD2=$(echo "$COMMENT_BODY" | awk 'NR==1{print $2}')
           if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
             echo "value=$WORD2" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/agent-issue-revise-plan.yml
+++ b/.github/workflows/agent-issue-revise-plan.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Export token for gh
         run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
+      - name: Parse model from trigger comment
+        id: model
+        run: |
+          set -euo pipefail
+          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
+            echo "value=$WORD2" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=sonnet" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -36,6 +47,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
+            --model ${{ steps.model.outputs.value }}
             --max-turns 60
             --settings ./claude/agents/planner.json
           prompt: |

--- a/.github/workflows/agent-issue-revise-plan.yml
+++ b/.github/workflows/agent-issue-revise-plan.yml
@@ -70,6 +70,12 @@ jobs:
 
             Output:
             - One issue comment only (the new plan).
+            - Before the approve/revise footer, include a model recommendation for the implementation agent:
+              <!-- next-model: X -->
+              where X is haiku, sonnet, or opus, based on the complexity of the work planned:
+              - haiku: trivial change (docs, minor copy, single-line fix, config tweak)
+              - sonnet: moderate change (typical feature, a few files, standard patterns)
+              - opus: complex change (multi-system, high-risk logic, intricate interactions)
 
             If requirements are ambiguous and you need a decision before revising:
             - Post an issue comment starting with "## Questions for human" and include numbered options.

--- a/.github/workflows/agent-issue-revise-plan.yml
+++ b/.github/workflows/agent-issue-revise-plan.yml
@@ -30,9 +30,11 @@ jobs:
 
       - name: Parse model from trigger comment
         id: model
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          WORD2=$(echo "$COMMENT_BODY" | awk 'NR==1{print $2}')
           if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
             echo "value=$WORD2" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/agent-pr-implement.yml
+++ b/.github/workflows/agent-pr-implement.yml
@@ -74,6 +74,17 @@ jobs:
           git config user.name "agentic-automation[bot]"
           git config user.email "agentic-automation[bot]@users.noreply.github.com"
 
+      - name: Parse model from trigger comment
+        id: model
+        run: |
+          set -euo pipefail
+          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
+            echo "value=$WORD2" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=opus" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -82,7 +93,7 @@ jobs:
           track_progress: true
           show_full_output: true
           claude_args: |
-            --model opus
+            --model ${{ steps.model.outputs.value }}
             --max-turns 120
             --settings ./claude/agents/implementer.json
           prompt: |
@@ -155,9 +166,16 @@ jobs:
             When complete:
             - Ensure everything is committed and pushed.
             - Post "## Implementation summary" with what changed + how verified.
+            - End your final comment with a model recommendation for the review agent:
+              <!-- next-model: X -->
+              where X is haiku, sonnet, or opus. Base the choice on the complexity of what was implemented:
+              - haiku: trivial change (docs, minor copy, single-line fix, config tweak)
+              - sonnet: moderate change (typical feature, a few files, standard patterns)
+              - opus: complex change (multi-system, high-risk logic, intricate interactions)
 
             If stopping early:
             - Commit+push (WIP ok), then post "## Handoff" with what's done / next / blockers.
+            - Include <!-- next-model: X --> at the end of the handoff comment using the same criteria above.
 
             8) Shell safety rules
             - Avoid shell pipelines/redirection (no &&, ||, |, >, 2>&1).
@@ -201,7 +219,14 @@ jobs:
           PR="$PR_NUMBER"
           REPO="${{ github.repository }}"
 
-          gh pr comment "$PR" --repo "$REPO" --body "/agent-review"
+          NEXT_MODEL="$(gh pr view "$PR" --repo "$REPO" --json comments \
+            -q '[.comments[].body | select(contains("<!-- next-model:"))] | last // ""' \
+            | grep -oP '(?<=<!-- next-model: )\w+' || true)"
+          if ! echo "$NEXT_MODEL" | grep -qE '^(opus|sonnet|haiku)$'; then
+            NEXT_MODEL="opus"
+          fi
+
+          gh pr comment "$PR" --repo "$REPO" --body "/agent-review $NEXT_MODEL"
 
       - name: On failure -> retry ladder / halt
         if: failure()

--- a/.github/workflows/agent-pr-implement.yml
+++ b/.github/workflows/agent-pr-implement.yml
@@ -76,9 +76,11 @@ jobs:
 
       - name: Parse model from trigger comment
         id: model
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          WORD2=$(echo "$COMMENT_BODY" | awk 'NR==1{print $2}')
           if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
             echo "value=$WORD2" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/agent-pr-review.yml
+++ b/.github/workflows/agent-pr-review.yml
@@ -68,9 +68,11 @@ jobs:
 
       - name: Parse model from trigger comment
         id: model
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
-          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          WORD2=$(echo "$COMMENT_BODY" | awk 'NR==1{print $2}')
           if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
             echo "value=$WORD2" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/agent-pr-review.yml
+++ b/.github/workflows/agent-pr-review.yml
@@ -66,6 +66,17 @@ jobs:
       - name: Checkout PR branch
         run: gh pr checkout ${{ github.event.issue.number }} --repo ${{ github.repository }}
 
+      - name: Parse model from trigger comment
+        id: model
+        run: |
+          set -euo pipefail
+          WORD2=$(echo "${{ github.event.comment.body }}" | awk 'NR==1{print $2}')
+          if echo "$WORD2" | grep -qE '^(opus|sonnet|haiku)$'; then
+            echo "value=$WORD2" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=opus" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Agent PR review (interactive comment mode)
         uses: anthropics/claude-code-action@v1
         with:
@@ -76,7 +87,7 @@ jobs:
           include_fix_links: true
           show_full_output: true
           claude_args: |
-            --model opus
+            --model ${{ steps.model.outputs.value }}
             --max-turns 45
             --settings ./claude/agents/reviewer.json
           prompt: |
@@ -168,6 +179,14 @@ jobs:
             or
             Verdict: CHANGES_REQUESTED
 
+            After the verdict, include a model recommendation for the next agent step:
+            <!-- next-model: X -->
+            where X is haiku, sonnet, or opus. For APPROVE this recommends nothing further; for
+            CHANGES_REQUESTED it recommends the model the implementer should use to fix the issues:
+            - haiku: only trivial fixes needed (typos, minor copy, single-line corrections)
+            - sonnet: moderate fixes (typical refactors, a few files, standard patterns)
+            - opus: complex fixes (logic errors, multi-system impact, high-risk changes)
+
       - name: Ensure review-round labels exist
         run: |
           set -euo pipefail
@@ -230,7 +249,14 @@ jobs:
               gh pr edit "$PR" --repo "$REPO" --add-label "REVIEW-ROUND-1" || true
             fi
 
-            gh pr comment "$PR" --repo "$REPO" --body "/agent-implement"
+            NEXT_MODEL="$(gh pr view "$PR" --repo "$REPO" --json comments \
+              -q '[.comments[].body | select(contains("<!-- next-model:"))] | last // ""' \
+              | grep -oP '(?<=<!-- next-model: )\w+' || true)"
+            if ! echo "$NEXT_MODEL" | grep -qE '^(opus|sonnet|haiku)$'; then
+              NEXT_MODEL="opus"
+            fi
+
+            gh pr comment "$PR" --repo "$REPO" --body "/agent-implement $NEXT_MODEL"
             exit 0
           fi
 


### PR DESCRIPTION
All four agent workflows now accept an optional model argument in their slash commands (haiku, sonnet, or opus). The argument is the second word of the trigger comment, e.g. '/agent-implement haiku'. Invalid or missing values fall back to the existing default (opus for implement/review, sonnet for plan/revise-plan).

For the implement→review and review→implement handoffs, the agent now embeds a <\!-- next-model: X --> recommendation in its final comment. The shell step that posts the follow-up trigger reads that tag and passes the chosen model to the next workflow, so the agent drives model selection across the full review cycle.

Co-authored-by: Andrew Johnson <andrewsjohnson@users.noreply.github.com>